### PR TITLE
feat(download): add source as a parameter

### DIFF
--- a/app/media/MyTerraform/modules/s3/main.tf
+++ b/app/media/MyTerraform/modules/s3/main.tf
@@ -1,0 +1,16 @@
+
+resource "aws_s3_bucket" "s3_bucket" {
+  count         = var.s3_create_bucket ? 1 : 0
+  bucket        = var.s3_bucket_name
+  force_destroy = var.s3_bucket_force_destroy
+  tags          = var.s3_bucket_tags
+}
+
+resource "aws_s3_bucket_versioning" "s3_bucket_versioning" {
+  count = var.s3_create_bucket && var.s3_create_bucket_versioning ? 1 : 0
+  bucket = aws_s3_bucket.s3_bucket[0].id
+
+  versioning_configuration {
+    status = var.s3_bucket_versioning_status
+  }
+}

--- a/app/media/MyTerraform/modules/s3/terraform.tfvars
+++ b/app/media/MyTerraform/modules/s3/terraform.tfvars
@@ -1,0 +1,10 @@
+
+s3_create_bucket = true
+s3_bucket_name = "UniqueName"
+s3_bucket_force_destroy = false
+s3_bucket_tags = {
+  Name        = "My bucket"
+  Environment = "Dev"
+}
+s3_create_bucket_versioning = false
+s3_bucket_versioning_status = "Enabled"

--- a/app/media/MyTerraform/modules/s3/variables.tf
+++ b/app/media/MyTerraform/modules/s3/variables.tf
@@ -1,0 +1,24 @@
+
+variable "s3_create_bucket" {
+  type = bool
+}
+
+variable "s3_bucket_name" {
+  type = string
+}
+
+variable "s3_bucket_force_destroy" {
+  type = bool
+}
+
+variable "s3_bucket_tags" {
+  type = map(string)
+}
+
+variable "s3_create_bucket_versioning" {
+  type = bool
+}
+
+variable "s3_bucket_versioning_status" {
+  type = string
+}

--- a/app/media/MyTerraform/modules/s3/versions.tf
+++ b/app/media/MyTerraform/modules/s3/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.20"
+    }
+  }
+}

--- a/app/routes/utils.py
+++ b/app/routes/utils.py
@@ -17,8 +17,8 @@ def zip_folder(folder_path: str, output_zip_path: str):
 
 
 
-@app.get("/download-folder{folder_name}")
-async def download_folder_MyHelm(folder_name: str):
+@app.get("/download-folder{folder_name}/{source}")
+async def download_folder_MyHelm(folder_name: str,source:str):
     folder_path = f"app/media/{folder_name}"  # Adjust the path as needed
     if not os.path.exists(folder_path):
         raise HTTPException(status_code=404, detail="Folder not found")
@@ -29,6 +29,6 @@ async def download_folder_MyHelm(folder_name: str):
     zip_folder(folder_path, zip_file_path)
 
     # Return the zip file as a response
-    return FileResponse(zip_file_path, media_type='application/zip', filename=f"app/media{folder_name}_zip.zip")
+    return FileResponse(zip_file_path, media_type='application/zip', filename=f"{folder_name}_{source}.zip")
 
 


### PR DESCRIPTION
the download API is: /download-folder{folder_name}/{source}
as you know, I have added source as an additional parameter to dedicate downloaded .zip files.
you should pass a 'source' depending on the API. For example if you generate IAM: /download-folderMyTerraform/IAM